### PR TITLE
Client-requested info on using Gravatars

### DIFF
--- a/content/managing-account.html
+++ b/content/managing-account.html
@@ -39,6 +39,10 @@
   * Enter the password again to confirm it.
   * Read and accept the Terms and Conditions.
   * Click the Sign up button. The system creates your free account, logs you in, and displays your personal Dashboard.
+  
+  TIP: Anaconda Cloud displays your profile photo if the email address you used to register on Anaconda Cloud is 
+  associated with a Gravatar account. Go to http://gravatar.com to associate your email address or to change your 
+  Gravatar profile photo.
 
   While you’re logged in, at the top right of each page in Anaconda Cloud, the user toolbar displays.
   ![Anaconda Cloud user toolbar]({{media_url('img/Anaconda-Cloud-User-Toolbar.jpg')}})
@@ -50,6 +54,7 @@
   3. Dashboard button. NOTE: When logged in, you can also click the Anaconda Cloud logo to reach your Dashboard.
   4. User Settings button
   5. Log Out button
+  
 
   Packages that you have created with this account appear on your Dashboard. There’s a handy button to create a new package.
 


### PR DESCRIPTION
Re Docs - Updating Profile Image is missing from docs #267 

Written as a tip because using a Gravatar is optional, not required, and the instructions are how to use a non-Continuum website.

@stephenakearns or @electronwill please review and merge.